### PR TITLE
More UI work for mobile and board improvements

### DIFF
--- a/5Straight/Pages/GameBoard.razor
+++ b/5Straight/Pages/GameBoard.razor
@@ -2,6 +2,7 @@
 
 @using _5Straight.Data
 @using _5Straight.Data.Models
+@using System.Text;
 @implements IDisposable
 @inject GameManager GameManager
 @inject NavigationManager NavigationManager
@@ -185,9 +186,24 @@ else
                                                     {
                                                         int locationNumber = GameFactory.positionOrder[position];
 
-                                                        string classString = "";
+                                                        StringBuilder classString = new StringBuilder("");
+                                                        BoardLocation location = game.Board.Where(x => x.Number.Equals(locationNumber)).FirstOrDefault();
 
-                                                        <td class="@(game.Board.Where(x => x.Number.Equals(locationNumber)).FirstOrDefault().FilledBy?.Team?.TeamColor ?? classString)" @onclick="() => MakePlay(locationNumber)" id="@locationNumber">@locationNumber</td>
+                                                        Play lastPlay = game.Plays.OrderBy(x => x.TurnNumber).ToList().LastOrDefault();
+                                                        classString.Append(location.FilledBy?.Team?.TeamColor ?? "");
+                                                        if (lastPlay != null && !lastPlay.Draw && lastPlay.PlayedLocationNumber.Equals(locationNumber))
+                                                        {
+                                                            classString.Append(" boardLastPlayedLoc");
+                                                        }
+                                                        @if (game.Players.Where(x => !string.IsNullOrWhiteSpace(x.PlayerOwner) && x.PlayerOwner.Equals(authState.User.Identity.Name)).Any())
+                                                        {
+                                                            Player player = game.Players.Where(x => !string.IsNullOrWhiteSpace(x.PlayerOwner) && x.PlayerOwner.Equals(authState.User.Identity.Name)).First();
+                                                            if (!location.Filled && !selectedCard.Equals(-1) && game.CurrentPlayer.Equals(player) && player.Hand[selectedCard] <= locationNumber)
+                                                            {
+                                                                classString.Append(" boardPlayable");
+                                                            }
+                                                        }
+                                                        <td class="@classString.ToString()" @onclick="() => MakePlay(locationNumber)" id="@locationNumber">@locationNumber</td>
                                                         position++;
                                                     }
                                                 }
@@ -368,19 +384,19 @@ else
 
         if (player == null)
         {
-            toastService.ShowError("You are not a player in this game.", "Error");
+            //toastService.ShowError("You are not a player in this game.", "Error");
             return;
         }
 
         if (game.CurrentPlayer != player)
         {
-            toastService.ShowError("It is not your turn to play.", "Error");
+            //toastService.ShowError("It is not your turn to play.", "Error");
             return;
         }
 
         if (player.Hand.Count <= selectedCard)
         {
-            toastService.ShowError("Select a valid card before you play.", "Error");
+            //toastService.ShowError("Select a valid card before you play.", "Error");
             return;
         }
 
@@ -389,7 +405,7 @@ else
         {
             toastService.ShowError(response, "");
         }
-
+        selectedCard = -1;
     }
 
     public async void MakeDraw()
@@ -407,6 +423,7 @@ else
         {
             toastService.ShowError(response, "Error");
         }
+        selectedCard = -1;
     }
 
     public void SelectCard(int cardSlot)

--- a/5Straight/Pages/GameHistory.razor
+++ b/5Straight/Pages/GameHistory.razor
@@ -17,46 +17,8 @@
                 <DataGrid TItem="Game" Data="@FilteredGames" Sortable="true" Filterable="true" Editable="false" ShowPager="true" PageSize="5" Striped="false" Bordered="true">
                     <DataGridColumn TItem="Game" Field="@nameof(Game.GameId)" Caption="Game ID" Editable="false"></DataGridColumn>
                     <DataGridColumn TItem="Game" Field="@nameof(Game.GameName)" Caption="Game Name" Editable="false"></DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="Teams" Editable="false" Sortable="false" Filterable="false">
-                        <DisplayTemplate>
-                            @{
-                                var teams = (context as Game)?.Teams;
-                                @($"{teams.Count()}")
-                            }
-                        </DisplayTemplate>
-                    </DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.Teams)" Caption="Players" Editable="false" Sortable="false" Filterable="false">
-                        <DisplayTemplate>
-                            @{
-                                var players = (context as Game)?.Players;
-                                @($"{players.Count()}")
-                            }
-                        </DisplayTemplate>
-                    </DataGridColumn>
                     <DataGridColumn TItem="Game" Field="@nameof(Game.TurnNumber)" Caption="Turns" Editable="false" Sortable="false" Filterable="false"></DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.WinningPlayer)" Caption="Winning Player" Editable="false" Sortable="false" Filterable="false">
-                        <DisplayTemplate>
-                            @{
-                                var player = (context as Game)?.WinningPlayer;
-                                if (player != null)
-                                {
-                                    @($"{player.PlayerOwner}")
-                                }
-                            }
-                        </DisplayTemplate>
-                    </DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.WinningPlayer)" Caption="Winning Team" Editable="false" Sortable="false" Filterable="false">
-                        <DisplayTemplate>
-                            @{
-                                var player = (context as Game)?.WinningPlayer;
-                                if (player != null)
-                                {
-                                    @($"{player.Team.TeamNumber}")
-                                }
-                            }
-                        </DisplayTemplate>
-                    </DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="View Game" Editable="false" Sortable="false" Filterable="false">
+                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="View" Editable="false" Sortable="false" Filterable="false">
                         <DisplayTemplate>
                             @{
                                 var game = (context as Game);

--- a/5Straight/Pages/Index.razor
+++ b/5Straight/Pages/Index.razor
@@ -7,17 +7,14 @@
 @inject NavigationManager NavigationManager
 @inject GameManager GameManager
 
-<Row>
+<Row> 
     <Column>
         <Card Margin="Margin.Is4.OnY">
             <CardHeader>
-                <CardTitle>Open Games</CardTitle>
+                <CardTitle Size="4" Weight="TextWeight.Bold">Open Games<Button style="float:right;" class="btn btn-sm btn-primary" Clicked="ShowNewGameModal">New Game</Button></CardTitle>
             </CardHeader>
             <CardBody>
-                <CardText Margin="Margin.Is3">Create a new game or join an open game! <Button class="btn btn-primary" Clicked="ShowNewGameModal">Create New Game</Button></CardText>
-
-                <DataGrid TItem="Game" Data="@Games.Values.Where(x => !x.GameHasStarted)" Sortable="true" Filterable="true" Editable="false" ShowPager="true" PageSize="5" Striped="false" Bordered="true">
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.GameId)" Caption="Game ID" Editable="false"></DataGridColumn>
+                <DataGrid TItem="Game" Data="@Games.Values.Where(x => !x.GameHasStarted)" Sortable="true" Filterable="true" Editable="false" ShowPager="true" PageSize="10" Striped="false" Bordered="true">
                     <DataGridColumn TItem="Game" Field="@nameof(Game.GameName)" Caption="Game Name" Editable="false"></DataGridColumn>
                     <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="Teams" Editable="false" Sortable="false" Filterable="false">
                         <DisplayTemplate>
@@ -32,22 +29,22 @@
                             @{
                                 var players = (context as Game)?.Players;
                                 var openPlayers = (context as Game)?.Players.Where(x => x.PlayerOwner.Equals(""));
-                                @($"{players.Count()-openPlayers.Count()}/{players.Count()} Filled")
+                                @($"{players.Count()-openPlayers.Count()}/{players.Count()}")
                             }
                         </DisplayTemplate>
                     </DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="Join Game" Editable="false" Sortable="false" Filterable="false">
+                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="Join" Editable="false" Sortable="false" Filterable="false">
                         <DisplayTemplate>
                             @{
                                 var game = (context as Game);
                                 var openPlayers = game?.Players.Where(x => x.PlayerOwner.Equals(""));
                                 if (openPlayers.Any())
                                 {
-                                    <a class="btn btn-primary" href="@($"/GameBoard/{game.GameId}")">Join</a>
+                                    <a class="btn btn-sm btn-primary" href="@($"/GameBoard/{game.GameId}")">Join</a>
                                 }
                                 else
                                 {
-                                    <a class="btn btn-primary" href="@($"/GameBoard/{game.GameId}")">Watch</a>
+                                    <a class="btn btn-sm btn-primary" href="@($"/GameBoard/{game.GameId}")">Watch</a>
                                 }
                             }
                         </DisplayTemplate>
@@ -56,31 +53,27 @@
             </CardBody>
         </Card>
     </Column>
-</Row>
-
-<Row>
     <Column>
         <Card Margin="Margin.Is4.OnY">
             <CardHeader>
-                <CardTitle>Live Games</CardTitle>
+                <CardTitle Size="4" Weight="TextWeight.Bold">Live Games</CardTitle>
             </CardHeader>
             <CardBody>
-                <DataGrid TItem="Game" Data="@Games.Values.Where(x => x.GameHasStarted && !x.Won)" Sortable="true" Filterable="true" Editable="false" ShowPager="true" PageSize="5" Striped="false" Bordered="true">
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.GameId)" Caption="Game ID" Editable="false"></DataGridColumn>
+                <DataGrid TItem="Game" Data="@Games.Values.Where(x => x.GameHasStarted && !x.Won)" Sortable="true" Filterable="true" Editable="false" ShowPager="true" PageSize="10" Striped="false" Bordered="true">
                     <DataGridColumn TItem="Game" Field="@nameof(Game.GameName)" Caption="Game Name" Editable="false"></DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.TurnNumber)" Caption="Turn Number" Editable="false" Sortable="false" Filterable="false"></DataGridColumn>
-                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="Join/Watch Game" Editable="false" Sortable="false" Filterable="false">
+                    <DataGridColumn TItem="Game" Field="@nameof(Game.TurnNumber)" Caption="Turn" Editable="false" Sortable="false" Filterable="false"></DataGridColumn>
+                    <DataGridColumn TItem="Game" Field="@nameof(Game.Players)" Caption="Join/Watch" Editable="false" Sortable="false" Filterable="false">
                         <DisplayTemplate>
                             @{
                                 var game = (context as Game);
                                 var ownedPlayer = game?.Players.Where(x => x.PlayerOwner.Equals(authState.User.Identity.Name));
                                 if (ownedPlayer.Any())
                                 {
-                                    <a class="btn btn-primary" href="@($"/GameBoard/{game.GameId}")">Continue Playing</a>
+                                    <a class="btn btn-sm btn-primary" href="@($"/GameBoard/{game.GameId}")">Continue</a>
                                 }
                                 else
                                 {
-                                    <a class="btn btn-primary" href="@($"/GameBoard/{game.GameId}")">Watch</a>
+                                    <a class="btn btn-sm btn-primary" href="@($"/GameBoard/{game.GameId}")">Watch</a>
                                 }
                             }
                         </DisplayTemplate>

--- a/5Straight/Shared/LoginDisplay.razor
+++ b/5Straight/Shared/LoginDisplay.razor
@@ -1,9 +1,8 @@
 ﻿<AuthorizeView>
     <Authorized>
-        Hello, @context.User.Identity.Name!
-        <a class="btn btn-primary" href="AzureAD/Account/SignOut">Log out</a>
+        <a class="btn btn-sm btn-primary" href="AzureAD/Account/SignOut">Log out</a>
     </Authorized>
     <NotAuthorized>
-        <a class="btn btn-primary" href="AzureAD/Account/SignIn">Log in</a>
+        <a class="btn btn-sm btn-primary" href="AzureAD/Account/SignIn">Log in</a>
     </NotAuthorized>
 </AuthorizeView>

--- a/5Straight/Shared/MainLayout.razor
+++ b/5Straight/Shared/MainLayout.razor
@@ -1,16 +1,21 @@
 ﻿@inherits LayoutComponentBase
 
     <BlazoredModal />
-    <BlazoredToasts />
+    <BlazoredToasts 
+                    Position="Blazored.Toast.Configuration.ToastPosition.TopRight"
+                    ErrorClass="ToastZ"
+                    SuccessClass="ToastZ"
+                    WarningClass="ToastZ"
+                    />
 
 <div class="sidebar">
     <NavMenu />
 </div>
 
 <div class="main">
-    <div class="top-row px-4 auth">
+    @*<div class="top-row px-4 auth">
         <LoginDisplay />
-    </div>
+    </div>*@
 
     <div class="content px-4">
         @Body

--- a/5Straight/Shared/NavMenu.razor
+++ b/5Straight/Shared/NavMenu.razor
@@ -7,13 +7,21 @@
 
 <div class="top-row pl-4 navbar navbar-dark">
     <a class="navbar-brand" href="">5ive Straight</a>
-    <button class="navbar-toggler" @onclick="ToggleNavMenu">
+    <LoginDisplay />
+    <button style="float:right;" class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
     </button>
 </div>
 
 <div class="@NavMenuCssClass" @onclick="ToggleNavMenu">
     <ul class="nav flex-column">
+        <NavLink class="nav-link" >
+            <Card Margin="Margin.Is1.FromBottom" Background="Background.Light" WhiteText="false" Style="color:black">
+                <CardBody Margin="Margin.Is0" Style="padding:.5rem">
+                   Welcome @authState.User.Identity.Name.Split('@')[0]!
+                </CardBody>
+            </Card>
+        </NavLink>
         <li class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="oi oi-home" aria-hidden="true"></span> Home
@@ -34,8 +42,10 @@
                 {
                     var gameName = game.Value.GameName.Substring(0, game.Value.GameName.Length > 20 ? 20 : game.Value.GameName.Length);
                     gameName = gameName.Length < game.Value.GameName.Length ? $"{gameName}..." : gameName;
+                    string cardClass = "";
+                    if (game.Value.GameHasStarted && game.Value.CurrentPlayer.PlayerOwner.Equals(authState.User.Identity.Name)) { cardClass = "shadowTurnIndicator"; }
                     <NavLink class="nav-link" href="@($"/GameBoard/{game.Value.GameId}")">
-                        <Card Margin="Margin.Is1.FromBottom" Background="Background.Light" WhiteText="false" Style="color:black">
+                        <Card Margin="Margin.Is1.FromBottom" Background="Background.Light" WhiteText="false" Style="color:black" Class="@cardClass">
                             <CardBody Margin="Margin.Is0" Style="padding:.5rem">
                                 <CardTitle Size="7">@gameName</CardTitle>
                                 <CardText>

--- a/5Straight/wwwroot/css/site.css
+++ b/5Straight/wwwroot/css/site.css
@@ -22,7 +22,7 @@ app {
 
 .top-row {
     height: 3.5rem;
-    display: flex;
+    display: block;
     align-items: center;
 }
 
@@ -196,6 +196,10 @@ app {
     text-align: center;
 }
 
+.shadowTurnIndicator {
+    box-shadow: 0 0 4px 4px gold;
+}
+
 /* Lobby CSS */
 
 #lobby-team-0 {
@@ -218,17 +222,23 @@ app {
 }
 
 /* Gameboard CSS*/
+
+.boardLastPlayedLoc {
+    background-color: darkgrey !important;
+    color: white !important;
+}
+
 #boardContainer {
     padding: 1%;
 }
 
-#boardUberContainer{
-    margin-top: 10px;
-    margin-bottom: 10px;
+#boardUberContainer {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
 }
 
 #board table, #board td {
-    border: 4px solid #545454;
+    border: .2rem solid #545454;
     border-collapse: collapse;
     background: #d3d3d3;
     color: black;
@@ -236,20 +246,20 @@ app {
 }
 
 #board td {
-    width: 2em;
-    height: 2em;
+    width: 4rem;
+    height: 4rem;
     text-align: center;
-    font-size: 2em;
+    font-size: 1.5rem;
 }
 
 @media (max-width: 1000px) {
     #board table, #board td {
-        border: 2px solid #545454;
+        border: .2rem solid #545454;
     }
 
     #board td {
-        width: 2em;
-        height: 2em;
+        width: 2.5em;
+        height: 2.5em;
         text-align: center;
         font-size: 1em;
     }
@@ -260,36 +270,38 @@ app {
     color: black;
 }
 
+.boardPlayable {
+    box-shadow: inset 0 0 .5rem .2rem lightgreen;
+}
+
 .teamColor0 {
-    outline: 5px solid var(--team0-color);
-    outline-offset: -8px;
+    box-shadow: inset 0 0 .5rem .2rem var(--team0-color);
 }
 
 .teamColor1 {
-    outline: 5px solid var(--team1-color);
-    outline-offset: -8px;
+    box-shadow: inset 0 0 .5rem .2rem var(--team1-color);
 }
 
 .teamColor2 {
-    outline: 5px solid var(--team2-color);
-    outline-offset: -8px;
+    box-shadow: inset 0 0 .5rem .2rem var(--team2-color);
 }
 
 .boardShadowTeam0 {
-    box-shadow: 0px 0px 10px 10px var(--team0-color);
+    box-shadow: 0 0 1rem .4rem var(--team0-color);
 }
 
 .boardShadowTeam1 {
-    box-shadow: 0px 0px 10px 10px var(--team1-color);
+    box-shadow: 0 0 1rem .4rem var(--team1-color);
 }
 
 .boardShadowTeam2 {
-    box-shadow: 0px 0px 10px 10px var(--team2-color);
+    box-shadow: 0 0 1rem .4rem var(--team2-color);
 }
 
 .boardShadow {
-    box-shadow: 0px 0px 10px 10px #e6ecf3;
+    box-shadow: 0 0 1rem .4rem #e6ecf3;
 }
+
 
 /* Game Info CSS */
 
@@ -336,4 +348,8 @@ thead {
 
 .page-item.active.disabled .page-link {
     color: white;
+}
+
+.ToastZ {
+    z-index: 12;
 }


### PR DESCRIPTION
- Removed top nav bar (we were not using it, and I think it looks better without)
- Moved login/logout button and User Login name to the left bar
- Put the Open and Running Games tables into columns next to each other, they float in mobile below 
- Added gold boarder to game cards when it is your turn (Still need to work on the notifications so it always updates properly..)
- Changed game board to use rem instead of px (huge improvement for flexibility)
- Changed outlines for owned spaces to drop shadows 
- Added Last Played darker background indicator 
- Added Playable green drop shadow based on selected card
- Removed a lot of columns from the history table because it causes issues with mobile, and Im going to move much of that info into the post game info box below the board when the game is over (to do)
- Removed some errors because they can be spammed and that's no fun.